### PR TITLE
Change torch installation using pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ RUN pip install scipy==1.7.3
 RUN pip install scikit-learn==1.0.2
 RUN pip install pandas==1.3.5
 RUN pip install matplotlib==3.5.3
+RUN pip install torch==1.5.0 torchvision==0.6.0
 RUN conda install openbabel=2.4.1 -c conda-forge
-RUN conda install pytorch==1.5.0 torchvision==0.6.0 cpuonly -c pytorch
+#RUN conda install pytorch==1.5.0 torchvision==0.6.0 cpuonly -c pytorch
 
 WORKDIR /repo
 COPY . /repo


### PR DESCRIPTION
Due to an error that occurred when trying to install torch using the conda channel.

PackagesNotFoundError: The following packages are not available from current channels:

   -torchvision==0.6.0

The installation was tested using pip, and the model successfully fetches and obtains the predictions.
The fetch model successfully in my CLI. 


[out_eos22io.csv](https://github.com/ersilia-os/eos22io/files/11030711/out_eos22io.csv)
